### PR TITLE
Settings: Add Help button for tutorial (no auto-onboarding)

### DIFF
--- a/src/components/OnboardingTutorial.tsx
+++ b/src/components/OnboardingTutorial.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { BlurView } from 'expo-blur';
+import { useTheme } from '../theme/theme';
+
+export default function OnboardingTutorial({ onClose }: { onClose: () => void }) {
+  const theme = useTheme() as any;
+  const { colors } = theme;
+
+  const Item = ({ emoji, title, desc }: { emoji: string; title: string; desc: string }) => (
+    <View
+      style={{
+        backgroundColor: colors.cardAlpha,
+        borderColor: colors.border,
+        borderWidth: 1,
+        borderRadius: theme.radius.lg,
+        padding: theme.spacing(2),
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+        <Text style={{ fontSize: 22 }}>{emoji}</Text>
+        <Text style={{ color: colors.text, fontWeight: '800', fontSize: 16 }}>{title}</Text>
+      </View>
+      <Text style={{ color: colors.subtext, lineHeight: 20 }}>{desc}</Text>
+    </View>
+  );
+
+  return (
+    <View
+      accessible
+      accessibilityLabel="アプリの使い方"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        backgroundColor: colors.overlay,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: theme.spacing(2),
+      }}
+    >
+      <BlurView intensity={30} tint="dark" style={{ width: '100%', borderRadius: theme.radius.lg, overflow: 'hidden' }}>
+        <View style={{ padding: theme.spacing(2) }}>
+          <View style={{ marginBottom: theme.spacing(1.5), alignItems: 'center' }}>
+            <Text style={{ color: colors.pink, fontWeight: '800', fontSize: 18 }}>Mamapace へようこそ</Text>
+            <Text style={{ color: colors.subtext, fontSize: 12, marginTop: 6 }}>安心・安全のためのポイント（1分で読めます）</Text>
+          </View>
+
+          <View style={{ gap: theme.spacing(1.5) }}>
+            <Item
+              emoji="🙊"
+              title="愚痴ルームは完全匿名"
+              desc="だれでも安心して吐き出せる場所。投稿は1時間で自動削除され、履歴に残りません。"
+            />
+            <Item
+              emoji="🤚"
+              title="“空き手”を設定して片手で使いやすく"
+              desc="設定 ＞ 空き手 から右/左を選ぶと、ボタンの位置があなたに合わせて移動します。いつでも変更できます。"
+            />
+            <Item
+              emoji="📚"
+              title="サイドバーの開き方"
+              desc="右利きはホーム、左利きはあなたのタブを長押しでサイドバーが開きます。ルームや設定に素早く移動できます。"
+            />
+          </View>
+
+          <View style={{ flexDirection: 'row', gap: 12, justifyContent: 'center', marginTop: theme.spacing(2) }}>
+            <Pressable
+              onPress={onClose}
+              accessibilityLabel="はじめる"
+              style={({ pressed }) => [{
+                backgroundColor: colors.pink,
+                borderRadius: theme.radius.md,
+                paddingVertical: 12,
+                paddingHorizontal: 18,
+                transform: [{ scale: pressed ? 0.98 : 1 }],
+              }]}
+            >
+              <Text style={{ color: '#1C1F25', fontWeight: '800' }}>はじめる</Text>
+            </Pressable>
+          </View>
+        </View>
+      </BlurView>
+    </View>
+  );
+}
+

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '../theme/theme';
 import { BlurView } from 'expo-blur';
 import { useAuth } from '../contexts/AuthContext';
 import { useHandPreference } from '../contexts/HandPreferenceContext';
+import OnboardingTutorial from '../components/OnboardingTutorial';
 import { notificationPreferencesService } from '../services/notificationPreferencesService';
 import { createBatchUpdater } from '../utils/batchUpdate';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -17,6 +18,7 @@ export default function SettingsScreen({
   const { colors } = theme;
   const fade = useRef(new Animated.Value(1)).current; // 初期値を1に設定してフラッシュを防ぐ
   const { logout, refreshToken, user } = useAuth();
+  const [showHelp, setShowHelp] = useState(false);
   const [prefs, setPrefs] = useState({
     allow_message: true,
     allow_room: true,
@@ -103,6 +105,9 @@ export default function SettingsScreen({
         opacity: fade,
       }}
     >
+      {showHelp && (
+        <OnboardingTutorial onClose={() => setShowHelp(false)} />
+      )}
       {/* Header with Mamapace Icon */}
       <ScrollView
         contentContainerStyle={{ paddingBottom: (insets.bottom || 0) + 56 + theme.spacing(6) }}
@@ -190,6 +195,25 @@ export default function SettingsScreen({
                 onPress={() => setHandPreference('right')}
               />
             </View>
+          </Section>
+          <View style={{ height: theme.spacing(2) }} />
+
+          <Section title="ヘルプ">
+            <Pressable
+              onPress={() => setShowHelp(true)}
+              style={({ pressed }) => [{
+                backgroundColor: colors.surface,
+                borderRadius: theme.radius.md,
+                paddingVertical: 12,
+                alignItems: 'center',
+                transform: [{ scale: pressed ? 0.98 : 1 }],
+                ...theme.shadow.card,
+              }]}
+            >
+              <Text style={{ color: colors.text, fontWeight: '700' }}>
+                使い方を見る（チュートリアル）
+              </Text>
+            </Pressable>
           </Section>
           <View style={{ height: theme.spacing(4) }} />
 


### PR DESCRIPTION
This PR:

- Adds a Help button in Settings to open a tutorial overlay (OnboardingTutorial)
- Removes any automatic onboarding overlay display; tutorial is user-invoked from Settings
- Tutorial content (consistent tone/colors):
  - Anonymous grumble room: fully anonymous, posts auto-delete in 1 hour
  - Hand preference (空き手): choose in Settings to move buttons
  - Sidebar usage: long-press Home (right-handed) or Me (left-handed)

No navigation structure changes; overlay is local to Settings.
