### PR TITLE
feat(search): support @display-name search (JP), result taps, and sch…

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  QueryKind,
+  parseQuery,
+  searchPostsByHashtag,
+  searchUsers,
+  SearchPostItem,
+  SearchUserItem,
+} from '../services/searchService';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+export function useSearch(input: string) {
+  const [status, setStatus] = useState<Status>('idle');
+  const [kind, setKind] = useState<QueryKind>('none');
+  const [users, setUsers] = useState<SearchUserItem[]>([]);
+  const [posts, setPosts] = useState<SearchPostItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const lastQuery = useRef<string>('');
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const parsed = useMemo(() => parseQuery(input), [input]);
+
+  useEffect(() => {
+    setKind(parsed.kind);
+    if (timer.current) {
+      clearTimeout(timer.current);
+    }
+
+    if (parsed.kind === 'none') {
+      setStatus('idle');
+      setUsers([]);
+      setPosts([]);
+      setError(null);
+      return;
+    }
+
+    setStatus('loading');
+    setError(null);
+    const qKey = `${parsed.kind}:${parsed.term}`;
+    lastQuery.current = qKey;
+
+    timer.current = setTimeout(async () => {
+      try {
+        if (lastQuery.current !== qKey) {
+          return; // outdated
+        }
+        if (parsed.kind === 'user') {
+          const { items } = await searchUsers(parsed.term, { limit: 20 });
+          if (lastQuery.current !== qKey) {
+            return;
+          }
+          setUsers(items);
+          setPosts([]);
+          setStatus('success');
+        } else if (parsed.kind === 'hashtag') {
+          const { items } = await searchPostsByHashtag(parsed.term, {
+            limit: 20,
+          });
+          if (lastQuery.current !== qKey) {
+            return;
+          }
+          setPosts(items);
+          setUsers([]);
+          setStatus('success');
+        }
+      } catch (e: any) {
+        if (lastQuery.current !== qKey) {
+          return;
+        }
+        setError(String(e?.message || '検索に失敗しました'));
+        setStatus('error');
+      }
+    }, 300);
+
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, [parsed.kind, parsed.term]);
+
+  return { status, kind, users, posts, error };
+}

--- a/src/navigation/CustomTabs.tsx
+++ b/src/navigation/CustomTabs.tsx
@@ -35,7 +35,7 @@ import AIChatBotScreen from '../screens/AIChatBotScreen';
 import LikedPostsListScreen from '../screens/LikedPostsListScreen';
 import MyPostsListScreen from '../screens/MyPostsListScreen';
 import LoginScreen from '../screens/LoginScreen';
-// import SearchScreen from '../screens/SearchScreen'; // Removed - now handled within RoomsScreen
+import SearchScreen from '../screens/SearchScreen';
 import SignUpScreen from '../screens/SignUpScreen';
 import ProfileEditScreen from '../screens/ProfileEditScreen';
 import UserProfileScreen from '../screens/UserProfileScreen';
@@ -72,7 +72,8 @@ type TabKey =
   | 'aiChat'
   | 'tutorial'
   | 'paywall'
-  | 'manageSubscription';
+  | 'manageSubscription'
+  | 'search';
 
 const tabs = [
   { key: 'me', label: 'あなた', Component: ProfileScreen },
@@ -301,25 +302,16 @@ export default function CustomTabs({
               }}
             />
           ) : active === 'search' ? (
-            // Redirect to home if search is accessed directly
-            (() => {
-              setActive('home');
-              return (
-                <HomeScreen
-                  refreshKey={homeRefreshKey}
-                  onCompose={() => setActive('compose')}
-                  onOpenPost={postId => {
-                    setActivePostId(postId);
-                    setActive('comments');
-                  }}
-                  onOpenProfileEdit={() => setActive('profileEdit')}
-                  onOpenUser={userId => {
-                    setActiveUserId(userId);
-                    setActive('userProfile');
-                  }}
-                />
-              );
-            })()
+            <SearchScreen
+              onOpenUser={userId => {
+                setActiveUserId(userId);
+                setActive('userProfile');
+              }}
+              onOpenPost={postId => {
+                setActivePostId(postId);
+                setActive('comments');
+              }}
+            />
           ) : active === 'rooms' ? (
             <ErrorBoundary>
               <RoomsScreen />

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -3,59 +3,35 @@ import {
   View,
   TextInput,
   Text,
-  Pressable,
   FlatList,
   KeyboardAvoidingView,
   Platform,
+  ActivityIndicator,
+  Image,
+  Pressable,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useTheme } from '../theme/theme';
 import { useBlockedList } from '../hooks/useBlock';
+import { useSearch } from '../hooks/useSearch';
+import type { SearchPostItem, SearchUserItem } from '../services/searchService';
 
-const tabs = [
-  { key: 'users', label: 'ユーザー' },
-  { key: 'rooms', label: 'ルーム' },
-  { key: 'tags', label: 'ハッシュタグ' },
-] as const;
-
-type TabKey = (typeof tabs)[number]['key'];
-
-type Item = { id: string; title: string; subtitle?: string };
-
-const MOCK = {
-  users: [
-    { id: 'u1', title: 'alice', subtitle: 'Alice A.' },
-    { id: 'u2', title: 'bob', subtitle: 'Bob B.' },
-  ],
-  rooms: [
-    { id: 'r1', title: 'General', subtitle: 'みんなで話そう' },
-    { id: 'r2', title: 'Random', subtitle: '雑談' },
-  ],
-  tags: [
-    { id: 't1', title: '#news' },
-    { id: 't2', title: '#reactnative' },
-  ],
-} satisfies Record<TabKey, Item[]>;
-
-export default function SearchScreen() {
+export default function SearchScreen({
+  onOpenUser,
+  onOpenPost,
+}: {
+  onOpenUser?: (userId: string) => void;
+  onOpenPost?: (postId: string) => void;
+}) {
   const { colors, radius } = useTheme();
   const [q, setQ] = useState('');
-  const [active, setActive] = useState<TabKey>('users');
   const { blocked } = useBlockedList();
+  const { status, kind, users, posts, error } = useSearch(q);
 
-  const data = useMemo(() => {
-    const filteredByText = MOCK[active].filter(
-      i =>
-        i.title.toLowerCase().includes(q.toLowerCase()) ||
-        (i.subtitle?.toLowerCase().includes(q.toLowerCase()) ?? false)
-    );
-    // ブロック除外はユーザータブのみ適用（id がユーザーID前提）
-    if (active === 'users') {
-      return filteredByText.filter(i => !blocked.includes(i.id));
-    }
-    return filteredByText;
-  }, [active, q, blocked]);
+  const filteredUsers = useMemo(() => {
+    return users.filter(u => !blocked.includes(u.id));
+  }, [users, blocked]);
 
   return (
     <KeyboardAvoidingView
@@ -76,7 +52,7 @@ export default function SearchScreen() {
         >
           <View style={{ flexDirection: 'row', marginBottom: 12 }}>
             <TextInput
-              placeholder="検索"
+              placeholder="検索（#ハッシュタグ または @ユーザー）"
               placeholderTextColor={colors.subtext}
               value={q}
               onChangeText={setQ}
@@ -95,69 +71,158 @@ export default function SearchScreen() {
               }}
             />
           </View>
-          <View
-            style={{ flexDirection: 'row', gap: 8 as any, marginBottom: 12 }}
-          >
-            {tabs.map(t => (
-              <Pressable
-                key={t.key}
-                accessibilityRole="tab"
-                accessibilityLabel={t.label}
-                onPress={() => setActive(t.key)}
-                style={({ pressed }) => [
-                  {
-                    paddingVertical: 8,
-                    paddingHorizontal: 12,
-                    borderRadius: radius.md,
-                    backgroundColor:
-                      active === t.key
-                        ? colors.pink
-                        : pressed
-                          ? '#ffffff10'
-                          : colors.card,
-                    borderColor: '#22252B',
-                    borderWidth: 1,
-                  },
-                ]}
-              >
-                <Text
-                  style={{
-                    color: active === t.key ? '#121418' : colors.text,
-                    fontWeight: '700',
-                  }}
-                >
-                  {t.label}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
-          <FlatList
-            keyboardShouldPersistTaps="handled"
-            data={data}
-            keyExtractor={i => i.id}
-            renderItem={({ item }) => (
-              <View
-                style={{
-                  paddingVertical: 12,
-                  paddingHorizontal: 12,
-                  borderRadius: radius.md,
-                  backgroundColor: colors.card,
-                  borderColor: '#22252B',
-                  borderWidth: 1,
-                  marginBottom: 8,
-                }}
-              >
-                <Text style={{ color: colors.text, fontWeight: '700' }}>
-                  {item.title}
-                </Text>
-                {!!item.subtitle && (
-                  <Text style={{ color: colors.subtext }}>{item.subtitle}</Text>
-                )}
-              </View>
-            )}
-          />
+          {status === 'idle' && (
+            <View style={{ paddingTop: 20 }}>
+              <HintRow
+                text="@alice でユーザーを検索"
+                colors={{ text: colors.text, sub: colors.subtext }}
+              />
+              <HintRow
+                text="#music でハッシュタグ検索"
+                colors={{ text: colors.text, sub: colors.subtext }}
+              />
+            </View>
+          )}
+          {status === 'loading' && (
+            <View style={{ paddingTop: 20, alignItems: 'center' }}>
+              <ActivityIndicator color={colors.pink} />
+              <Text style={{ marginTop: 8, color: colors.subtext }}>
+                検索中…
+              </Text>
+            </View>
+          )}
+          {status === 'error' && (
+            <View style={{ paddingTop: 20, alignItems: 'center' }}>
+              <Text style={{ color: colors.text, fontWeight: '700' }}>
+                エラー
+              </Text>
+              <Text style={{ color: colors.subtext, marginTop: 6 }}>
+                {error}
+              </Text>
+            </View>
+          )}
+          {status === 'success' && kind === 'user' && (
+            <FlatList
+              keyboardShouldPersistTaps="handled"
+              data={filteredUsers}
+              keyExtractor={i => i.id}
+              renderItem={({ item }) => (
+                <UserRow
+                  item={item}
+                  onPress={() => onOpenUser && onOpenUser(item.id)}
+                />
+              )}
+            />
+          )}
+          {status === 'success' && kind === 'hashtag' && (
+            <FlatList
+              keyboardShouldPersistTaps="handled"
+              data={posts}
+              keyExtractor={i => i.id}
+              renderItem={({ item }) => (
+                <PostRow
+                  item={item}
+                  onPress={() => onOpenPost && onOpenPost(item.id)}
+                />
+              )}
+            />
+          )}
         </View>
       </SafeAreaView>
     </KeyboardAvoidingView>
+  );
+}
+
+function HintRow({
+  text,
+  colors,
+}: {
+  text: string;
+  colors: { text: string; sub: string };
+}) {
+  return (
+    <View style={{ marginBottom: 10 }}>
+      <Text style={{ color: colors.sub }}>{text}</Text>
+    </View>
+  );
+}
+
+function UserRow({
+  item,
+  onPress,
+}: {
+  item: SearchUserItem;
+  onPress?: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: 10,
+      }}
+    >
+      {item.avatarUrl ? (
+        <Image
+          source={{ uri: item.avatarUrl }}
+          style={{ width: 36, height: 36, borderRadius: 18, marginRight: 12 }}
+        />
+      ) : item.avatarEmoji ? (
+        <View
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            marginRight: 12,
+            backgroundColor: '#ffffff10',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontSize: 20 }}>{item.avatarEmoji}</Text>
+        </View>
+      ) : (
+        <View
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            marginRight: 12,
+            backgroundColor: '#ffffff10',
+          }}
+        />
+      )}
+      <View style={{ flex: 1 }}>
+        <Text style={{ color: colors.text, fontWeight: '700' }}>
+          @{item.username}
+        </Text>
+        {!!item.displayName && (
+          <Text style={{ color: colors.subtext }}>{item.displayName}</Text>
+        )}
+      </View>
+    </Pressable>
+  );
+}
+
+function PostRow({
+  item,
+  onPress,
+}: {
+  item: SearchPostItem;
+  onPress?: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <Pressable style={{ paddingVertical: 10 }} onPress={onPress}>
+      <Text style={{ color: colors.text }}>
+        @{item.author.username} ·{' '}
+        {new Date(item.createdAt).toLocaleDateString()}
+      </Text>
+      <Text style={{ color: colors.subtext, marginTop: 4 }}>
+        {item.contentPreview}
+      </Text>
+    </Pressable>
   );
 }

--- a/src/services/__tests__/searchService.parseQuery.test.ts
+++ b/src/services/__tests__/searchService.parseQuery.test.ts
@@ -1,0 +1,28 @@
+import { parseQuery } from '../../services/searchService';
+
+describe('parseQuery', () => {
+  it('returns none for empty or whitespace', () => {
+    expect(parseQuery('')).toEqual({ kind: 'none', term: '' });
+    expect(parseQuery('   ')).toEqual({ kind: 'none', term: '' });
+  });
+
+  it('parses user queries with @', () => {
+    expect(parseQuery('@alice')).toEqual({ kind: 'user', term: 'alice' });
+    expect(parseQuery('@Alice')).toEqual({ kind: 'user', term: 'Alice' });
+  });
+
+  it('sanitizes username to allowed chars', () => {
+    expect(parseQuery('@bob!!')).toEqual({ kind: 'user', term: 'bob' });
+    expect(parseQuery('@eve.name')).toEqual({ kind: 'user', term: 'eve.name' });
+    expect(parseQuery('@john_doe+plus')).toEqual({
+      kind: 'user',
+      term: 'john_doeplus',
+    });
+  });
+
+  it('parses hashtag queries with Japanese letters and sanitizes', () => {
+    expect(parseQuery('#ReactNative')).toEqual({ kind: 'hashtag', term: 'ReactNative' });
+    expect(parseQuery('#dev!')).toEqual({ kind: 'hashtag', term: 'dev' });
+    expect(parseQuery('#日本語')).toEqual({ kind: 'hashtag', term: '日本語' });
+  });
+});

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,0 +1,164 @@
+import { getSupabaseClient } from './supabaseClient';
+
+export type QueryKind = 'user' | 'hashtag' | 'none';
+
+export type SearchUserItem = {
+  id: string;
+  username: string;
+  displayName?: string | null;
+  // Emoji-based avatar used in this app's schema
+  avatarEmoji?: string | null;
+  // Optional URL avatar for future support; not used currently
+  avatarUrl?: string | null;
+};
+
+export type SearchPostItem = {
+  id: string;
+  author: SearchUserItem;
+  contentPreview: string;
+  createdAt: string;
+};
+
+export function parseQuery(q: string): { kind: QueryKind; term: string } {
+  const raw = (q || '').trim();
+  if (!raw) {
+    return { kind: 'none', term: '' };
+  }
+
+  if (raw.startsWith('@')) {
+    // @ ではユーザー名だけでなく表示名も検索対象にするため
+    // 文字種を制限せず、Unicode 正規化 + トリムのみ行う
+    const term = raw
+      .slice(1)
+      .normalize('NFKC')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 48);
+    return { kind: term ? 'user' : 'none', term };
+  }
+  if (raw.startsWith('#')) {
+    // 日本語タグ対応: 全角含む文字を許容（Unicodeの文字/数字、_、中点・長音）
+    const normalized = raw.slice(1).normalize('NFKC');
+    const term = (normalized.match(/[\p{L}\p{N}_ー・]+/gu)?.join('') || '')
+      .trim()
+      .slice(0, 48);
+    return { kind: term ? 'hashtag' : 'none', term };
+  }
+
+  return { kind: 'none', term: '' };
+}
+
+export async function searchUsers(
+  term: string,
+  opts?: { limit?: number; cursor?: string }
+): Promise<{ items: SearchUserItem[]; nextCursor?: string | null }> {
+  const client = getSupabaseClient();
+  const limit = Math.min(Math.max(opts?.limit ?? 20, 1), 50);
+  const q = `%${term}%`;
+
+  // username と display_name を両方対象に検索
+  const makeBase = () =>
+    client.from('user_profiles').select('id, username, display_name, avatar_emoji');
+
+  const [byUsername, byDisplayName] = await Promise.all([
+    makeBase().ilike('username', q).order('username', { ascending: true }),
+    makeBase().ilike('display_name', q).order('display_name', { ascending: true }),
+  ]);
+
+  if (byUsername.error) throw byUsername.error;
+  if (byDisplayName.error) throw byDisplayName.error;
+
+  const seen = new Set<string>();
+  const merged: any[] = [];
+  for (const r of byUsername.data || []) {
+    const id = String(r.id);
+    if (!seen.has(id)) {
+      seen.add(id);
+      merged.push(r);
+    }
+  }
+  for (const r of byDisplayName.data || []) {
+    const id = String(r.id);
+    if (!seen.has(id)) {
+      seen.add(id);
+      merged.push(r);
+    }
+  }
+
+  const items: SearchUserItem[] = merged.slice(0, limit).map((r: any) => ({
+    id: String(r.id),
+    username: String(r.username),
+    displayName: r.display_name ?? null,
+    avatarEmoji: r.avatar_emoji ?? null,
+    avatarUrl: null,
+  }));
+  return { items, nextCursor: null };
+}
+
+export async function searchPostsByHashtag(
+  tag: string,
+  opts?: { limit?: number; cursor?: string }
+): Promise<{ items: SearchPostItem[]; nextCursor?: string | null }> {
+  const client = getSupabaseClient();
+  const limit = Math.min(Math.max(opts?.limit ?? 20, 1), 50);
+
+  // 1) hashtag から post_id 群を取得
+  const { data: ids, error: idErr } = await client
+    .from('post_hashtags')
+    .select('post_id')
+    .eq('tag', tag)
+    .limit(200);
+  if (idErr) {
+    throw idErr;
+  }
+  const postIds = (ids || []).map(x => x.post_id);
+  if (!postIds.length) {
+    return { items: [], nextCursor: null };
+  }
+
+  // 2) posts_filtered ビューから投稿を取得（RLS/権限下で読める）
+  const { data: posts, error: postErr } = await client
+    .from('posts_filtered')
+    .select('id, user_id, body, created_at')
+    .in('id', postIds)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (postErr) {
+    throw postErr;
+  }
+
+  const authorsNeeded = Array.from(
+    new Set((posts || []).map((p: any) => String(p.user_id))),
+  );
+
+  // 3) 著者プロフィールをまとめて取得
+  let authorMap = new Map<string, any>();
+  if (authorsNeeded.length) {
+    const { data: authors, error: authorErr } = await client
+      .from('user_profiles')
+      .select('id, username, display_name, avatar_emoji')
+      .in('id', authorsNeeded);
+    if (authorErr) {
+      throw authorErr;
+    }
+    authorMap = new Map((authors || []).map((a: any) => [String(a.id), a]));
+  }
+
+  const items: SearchPostItem[] = (posts || []).map((p: any) => {
+    const a = authorMap.get(String(p.user_id)) || {};
+    return {
+      id: String(p.id),
+      contentPreview: String(p.body || '').slice(0, 120),
+      createdAt: String(p.created_at),
+      author: {
+        id: String(a.id || ''),
+        username: String(a.username || ''),
+        displayName: a.display_name ?? null,
+        avatarEmoji: a.avatar_emoji ?? null,
+        avatarUrl: null,
+      },
+    };
+  });
+
+  return { items, nextCursor: null };
+}

--- a/supabase/sql/2025-09-19_post_hashtags.sql
+++ b/supabase/sql/2025-09-19_post_hashtags.sql
@@ -1,0 +1,19 @@
+-- Hashtag search support (idempotent, minimal privileges)
+-- This migration creates a mapping table from posts to hashtags and an index for case-insensitive search.
+
+-- 1) Table
+create table if not exists public.post_hashtags (
+  post_id uuid not null references public.posts(id) on delete cascade,
+  tag text not null,
+  created_at timestamptz not null default now(),
+  primary key (post_id, tag)
+);
+
+-- 2) Index for case-insensitive matching
+create index if not exists idx_post_hashtags_tag_lower on public.post_hashtags (lower(tag));
+create index if not exists idx_post_hashtags_post_id on public.post_hashtags (post_id);
+
+-- 3) RLS (keep permissive for now; rely on posts RLS for final visibility)
+-- We do not enable RLS here to avoid accidental access blocking during rollout.
+-- If needed later, enable RLS with policies that allow join through visible posts only.
+

--- a/supabase/sql/2025-09-19_post_hashtags_rls.sql
+++ b/supabase/sql/2025-09-19_post_hashtags_rls.sql
@@ -1,0 +1,8 @@
+-- Enable RLS for post_hashtags and add basic authenticated read policy
+
+alter table if exists public.post_hashtags enable row level security;
+
+create policy if not exists post_hashtags_select_authenticated
+  on public.post_hashtags
+  for select using (auth.role() = 'authenticated');
+

--- a/supabase/sql/2025-09-19_post_hashtags_tag_index.sql
+++ b/supabase/sql/2025-09-19_post_hashtags_tag_index.sql
@@ -1,0 +1,2 @@
+-- Add btree index for equality search on tag (Japanese-friendly)
+create index if not exists idx_post_hashtags_tag on public.post_hashtags(tag);


### PR DESCRIPTION
…ema alignment\n\n- Search users by username and display_name (Unicode, Japanese OK)\n- Add tap handling in Search screen to open user/profile and post/comments\n- Align with DB: use avatar_emoji, use posts_filtered for RLS-safe reads\n- Hashtag search: depend on post_hashtags mapping (include migrations)